### PR TITLE
Create Tech Stack docs

### DIFF
--- a/techstack.md
+++ b/techstack.md
@@ -1,30 +1,34 @@
 <!--
---- Readme.md Snippet without images Start ---
+&lt;--- Readme.md Snippet without images Start ---&gt;
 ## Tech Stack
 spryker-community/shadow is built on the following main stack:
+
 - [Golang](http://golang.org/) – Languages
 - [Shell](https://en.wikipedia.org/wiki/Shell_script) – Shells
 - [GitHub Actions](https://github.com/features/actions) – Continuous Integration
 
 Full tech stack [here](/techstack.md)
---- Readme.md Snippet without images End ---
 
---- Readme.md Snippet with images Start ---
+&lt;--- Readme.md Snippet without images End ---&gt;
+
+&lt;--- Readme.md Snippet with images Start ---&gt;
 ## Tech Stack
 spryker-community/shadow is built on the following main stack:
+
 - <img width='25' height='25' src='https://img.stackshare.io/service/1005/O6AczwfV_400x400.png' alt='Golang'/> [Golang](http://golang.org/) – Languages
 - <img width='25' height='25' src='https://img.stackshare.io/service/4631/default_c2062d40130562bdc836c13dbca02d318205a962.png' alt='Shell'/> [Shell](https://en.wikipedia.org/wiki/Shell_script) – Shells
 - <img width='25' height='25' src='https://img.stackshare.io/service/11563/actions.png' alt='GitHub Actions'/> [GitHub Actions](https://github.com/features/actions) – Continuous Integration
 
 Full tech stack [here](/techstack.md)
---- Readme.md Snippet with images End ---
+
+&lt;--- Readme.md Snippet with images End ---&gt;
 -->
 <div align="center">
 
 # Tech Stack File
 ![](https://img.stackshare.io/repo.svg "repo") [spryker-community/shadow](https://github.com/spryker-community/shadow)![](https://img.stackshare.io/public_badge.svg "public")
 <br/><br/>
-|4<br/>Tools used|11/09/23 <br/>Report generated|
+|16<br/>Tools used|12/14/23 <br/>Report generated|
 |------|------|
 </div>
 
@@ -75,7 +79,27 @@ Full tech stack [here](/techstack.md)
 </tr>
 </table>
 
+
+## <img src='https://img.stackshare.io/group.svg' /> Open source packages (12)</h2>
+
+## <img width='24' height='24' src='https://img.stackshare.io/service/21112/default_1346bbda8fe03e4dce5601323a3ca47a10c1ae36.png'/> Go Packages (12)
+
+|NAME|VERSION|LAST UPDATED|LAST UPDATED BY|LICENSE|VULNERABILITIES|
+|:------|:------|:------|:------|:------|:------|
+|[afero](https://pkg.go.dev/github.com/spf13/afero)|v1.9.2|11/01/22|andreaspenz |Apache-2.0|N/A|
+|[errors](https://pkg.go.dev/github.com/pkg/errors)|v0.9.1|11/01/22|andreaspenz |BSD-2-Clause|N/A|
+|[go-colorable](https://pkg.go.dev/github.com/mattn/go-colorable)|v0.1.11|11/01/22|andreaspenz |MIT|N/A|
+|[go-homedir](https://pkg.go.dev/github.com/mitchellh/go-homedir)|v1.1.0|11/01/22|andreaspenz |MIT|N/A|
+|[go-isatty](https://pkg.go.dev/github.com/mattn/go-isatty)|v0.0.14|11/01/22|andreaspenz |MIT|N/A|
+|[go-runewidth](https://pkg.go.dev/github.com/mattn/go-runewidth)|v0.0.9|11/01/22|andreaspenz |MIT|N/A|
+|[kr/text](https://pkg.go.dev/github.com/kr/text)|v0.1.0|11/01/22|andreaspenz |MIT|N/A|
+|[pretty](https://pkg.go.dev/github.com/kr/pretty)|v0.1.0|11/01/22|andreaspenz |MIT|N/A|
+|[sys](https://pkg.go.dev/golang.org/x/sys)|v0.0.0|11/01/22|andreaspenz |BSD-3-Clause|N/A|
+|[tablewriter](https://pkg.go.dev/github.com/olekukonko/tablewriter)|v0.0.5|11/01/22|andreaspenz |MIT|N/A|
+|[text](https://pkg.go.dev/golang.org/x/text)|v0.0.0|11/01/22|andreaspenz |BSD-3-Clause|N/A|
+|[zerolog](https://pkg.go.dev/github.com/rs/zerolog)|v1.26.0|11/01/22|andreaspenz |MIT|N/A|
+
 <br/>
 <div align='center'>
 
-Generated via [Stack File](https://github.com/apps/stack-file)
+Generated via [Stack File](https://github.com/marketplace/stack-file)

--- a/techstack.md
+++ b/techstack.md
@@ -28,7 +28,7 @@ Full tech stack [here](/techstack.md)
 # Tech Stack File
 ![](https://img.stackshare.io/repo.svg "repo") [spryker-community/shadow](https://github.com/spryker-community/shadow)![](https://img.stackshare.io/public_badge.svg "public")
 <br/><br/>
-|16<br/>Tools used|01/04/24 <br/>Report generated|
+|16<br/>Tools used|01/05/24 <br/>Report generated|
 |------|------|
 </div>
 

--- a/techstack.md
+++ b/techstack.md
@@ -28,7 +28,7 @@ Full tech stack [here](/techstack.md)
 # Tech Stack File
 ![](https://img.stackshare.io/repo.svg "repo") [spryker-community/shadow](https://github.com/spryker-community/shadow)![](https://img.stackshare.io/public_badge.svg "public")
 <br/><br/>
-|16<br/>Tools used|12/14/23 <br/>Report generated|
+|16<br/>Tools used|01/04/24 <br/>Report generated|
 |------|------|
 </div>
 

--- a/techstack.md
+++ b/techstack.md
@@ -1,0 +1,81 @@
+<!--
+--- Readme.md Snippet without images Start ---
+## Tech Stack
+spryker-community/shadow is built on the following main stack:
+- [Golang](http://golang.org/) – Languages
+- [Shell](https://en.wikipedia.org/wiki/Shell_script) – Shells
+- [GitHub Actions](https://github.com/features/actions) – Continuous Integration
+
+Full tech stack [here](/techstack.md)
+--- Readme.md Snippet without images End ---
+
+--- Readme.md Snippet with images Start ---
+## Tech Stack
+spryker-community/shadow is built on the following main stack:
+- <img width='25' height='25' src='https://img.stackshare.io/service/1005/O6AczwfV_400x400.png' alt='Golang'/> [Golang](http://golang.org/) – Languages
+- <img width='25' height='25' src='https://img.stackshare.io/service/4631/default_c2062d40130562bdc836c13dbca02d318205a962.png' alt='Shell'/> [Shell](https://en.wikipedia.org/wiki/Shell_script) – Shells
+- <img width='25' height='25' src='https://img.stackshare.io/service/11563/actions.png' alt='GitHub Actions'/> [GitHub Actions](https://github.com/features/actions) – Continuous Integration
+
+Full tech stack [here](/techstack.md)
+--- Readme.md Snippet with images End ---
+-->
+<div align="center">
+
+# Tech Stack File
+![](https://img.stackshare.io/repo.svg "repo") [spryker-community/shadow](https://github.com/spryker-community/shadow)![](https://img.stackshare.io/public_badge.svg "public")
+<br/><br/>
+|4<br/>Tools used|11/09/23 <br/>Report generated|
+|------|------|
+</div>
+
+## <img src='https://img.stackshare.io/languages.svg'/> Languages (1)
+<table><tr>
+  <td align='center'>
+  <img width='36' height='36' src='https://img.stackshare.io/service/1005/O6AczwfV_400x400.png' alt='Golang'>
+  <br>
+  <sub><a href="http://golang.org/">Golang</a></sub>
+  <br>
+  <sub></sub>
+</td>
+
+</tr>
+</table>
+
+## <img src='https://img.stackshare.io/devops.svg'/> DevOps (2)
+<table><tr>
+  <td align='center'>
+  <img width='36' height='36' src='https://img.stackshare.io/service/1046/git.png' alt='Git'>
+  <br>
+  <sub><a href="http://git-scm.com/">Git</a></sub>
+  <br>
+  <sub></sub>
+</td>
+
+<td align='center'>
+  <img width='36' height='36' src='https://img.stackshare.io/service/11563/actions.png' alt='GitHub Actions'>
+  <br>
+  <sub><a href="https://github.com/features/actions">GitHub Actions</a></sub>
+  <br>
+  <sub></sub>
+</td>
+
+</tr>
+</table>
+
+## Other (1)
+<table><tr>
+  <td align='center'>
+  <img width='36' height='36' src='https://img.stackshare.io/service/4631/default_c2062d40130562bdc836c13dbca02d318205a962.png' alt='Shell'>
+  <br>
+  <sub><a href="https://en.wikipedia.org/wiki/Shell_script">Shell</a></sub>
+  <br>
+  <sub></sub>
+</td>
+
+</tr>
+</table>
+
+<br/>
+<div align='center'>
+
+Generated via [Stack File](https://github.com/apps/stack-file)

--- a/techstack.yml
+++ b/techstack.yml
@@ -2,7 +2,7 @@ repo_name: spryker-community/shadow
 report_id: a5320f3504d8556879877fd58e6e7a18
 version: 0.1
 repo_type: Public
-timestamp: '2024-01-04T15:09:37+00:00'
+timestamp: '2024-01-05T09:11:25+00:00'
 requested_by: gxjansen
 provider: github
 branch: master

--- a/techstack.yml
+++ b/techstack.yml
@@ -1,7 +1,8 @@
 repo_name: spryker-community/shadow
-report_id: bf8202bc4d8cfb02ca2dc895f42fe33c
+report_id: a5320f3504d8556879877fd58e6e7a18
+version: 0.1
 repo_type: Public
-timestamp: '2023-12-14T09:51:49+00:00'
+timestamp: '2024-01-04T15:09:37+00:00'
 requested_by: gxjansen
 provider: github
 branch: master
@@ -17,6 +18,7 @@ tools:
   category: Languages & Frameworks
   sub_category: Languages
   image_url: https://img.stackshare.io/service/1005/O6AczwfV_400x400.png
+  detection_source_url: https://github.com/spryker-community/shadow
   detection_source: Repo Metadata
 - name: Git
   description: Fast, scalable, distributed revision control system
@@ -26,6 +28,7 @@ tools:
   category: Build, Test, Deploy
   sub_category: Version Control System
   image_url: https://img.stackshare.io/service/1046/git.png
+  detection_source_url: https://github.com/spryker-community/shadow
   detection_source: Repo Metadata
 - name: GitHub Actions
   description: Automate your workflow from idea to production
@@ -35,6 +38,7 @@ tools:
   category: Build, Test, Deploy
   sub_category: Continuous Integration
   image_url: https://img.stackshare.io/service/11563/actions.png
+  detection_source_url: https://github.com/spryker-community/shadow/blob/master/.github/workflows/build.yml
   detection_source: ".github/workflows/build.yml"
   last_updated_by: andreaspenz
   last_updated_on: 2022-11-01 17:27:34.000000000 Z
@@ -47,6 +51,7 @@ tools:
   category: Languages & Frameworks
   sub_category: Languages
   image_url: https://img.stackshare.io/service/4631/default_c2062d40130562bdc836c13dbca02d318205a962.png
+  detection_source_url: https://github.com/spryker-community/shadow
   detection_source: Repo Metadata
 - name: afero
   description: A FileSystem Abstraction System for Go

--- a/techstack.yml
+++ b/techstack.yml
@@ -1,0 +1,50 @@
+repo_name: spryker-community/shadow
+report_id: a5320f3504d8556879877fd58e6e7a18
+repo_type: Public
+timestamp: '2023-11-09T17:23:07+00:00'
+requested_by: andreaspenz
+provider: github
+branch: master
+detected_tools_count: 4
+tools:
+- name: Golang
+  description: An open source programming language that makes it easy to build simple,
+    reliable, and efficient software
+  website_url: http://golang.org/
+  license: BSD-3-Clause
+  open_source: true
+  hosted_saas: false
+  category: Languages & Frameworks
+  sub_category: Languages
+  image_url: https://img.stackshare.io/service/1005/O6AczwfV_400x400.png
+  detection_source: Repo Metadata
+- name: Git
+  description: Fast, scalable, distributed revision control system
+  website_url: http://git-scm.com/
+  open_source: true
+  hosted_saas: false
+  category: Build, Test, Deploy
+  sub_category: Version Control System
+  image_url: https://img.stackshare.io/service/1046/git.png
+  detection_source: Repo Metadata
+- name: GitHub Actions
+  description: Automate your workflow from idea to production
+  website_url: https://github.com/features/actions
+  open_source: false
+  hosted_saas: true
+  category: Build, Test, Deploy
+  sub_category: Continuous Integration
+  image_url: https://img.stackshare.io/service/11563/actions.png
+  detection_source: ".github/workflows/build.yml"
+  last_updated_by: andreaspenz
+  last_updated_on: 2022-11-01 17:27:34.000000000 Z
+- name: Shell
+  description: A shell is a text-based terminal, used for manipulating programs and
+    files. Shell scripts typically manage program execution.
+  website_url: https://en.wikipedia.org/wiki/Shell_script
+  open_source: false
+  hosted_saas: false
+  category: Languages & Frameworks
+  sub_category: Languages
+  image_url: https://img.stackshare.io/service/4631/default_c2062d40130562bdc836c13dbca02d318205a962.png
+  detection_source: Repo Metadata

--- a/techstack.yml
+++ b/techstack.yml
@@ -1,11 +1,11 @@
 repo_name: spryker-community/shadow
-report_id: a5320f3504d8556879877fd58e6e7a18
+report_id: bf8202bc4d8cfb02ca2dc895f42fe33c
 repo_type: Public
-timestamp: '2023-11-09T17:23:07+00:00'
-requested_by: andreaspenz
+timestamp: '2023-12-14T09:51:49+00:00'
+requested_by: gxjansen
 provider: github
 branch: master
-detected_tools_count: 4
+detected_tools_count: 16
 tools:
 - name: Golang
   description: An open source programming language that makes it easy to build simple,
@@ -48,3 +48,173 @@ tools:
   sub_category: Languages
   image_url: https://img.stackshare.io/service/4631/default_c2062d40130562bdc836c13dbca02d318205a962.png
   detection_source: Repo Metadata
+- name: afero
+  description: A FileSystem Abstraction System for Go
+  package_url: https://pkg.go.dev/github.com/spf13/afero
+  version: 1.9.2
+  license: Apache-2.0
+  open_source: true
+  hosted_saas: false
+  category: Libraries
+  sub_category: Go Modules Packages
+  image_url: https://img.stackshare.io/package/go-packages/image.png
+  detection_source_url: https://github.com/spryker-community/shadow/blob/master/go.sum
+  detection_source: go.mod
+  last_updated_by: andreaspenz
+  last_updated_on: 2022-11-01 17:27:34.000000000 Z
+- name: errors
+  description: Simple error handling primitives
+  package_url: https://pkg.go.dev/github.com/pkg/errors
+  version: 0.9.1
+  license: BSD-2-Clause
+  open_source: true
+  hosted_saas: false
+  category: Libraries
+  sub_category: Go Modules Packages
+  image_url: https://img.stackshare.io/package/go-packages/image.png
+  detection_source_url: https://github.com/spryker-community/shadow/blob/master/go.sum
+  detection_source: go.mod
+  last_updated_by: andreaspenz
+  last_updated_on: 2022-11-01 17:27:34.000000000 Z
+- name: go-colorable
+  description: Go-colorable Colorable writer for windows
+  package_url: https://pkg.go.dev/github.com/mattn/go-colorable
+  version: 0.1.11
+  license: MIT
+  open_source: true
+  hosted_saas: false
+  category: Libraries
+  sub_category: Go Modules Packages
+  image_url: https://img.stackshare.io/package/go-packages/image.png
+  detection_source_url: https://github.com/spryker-community/shadow/blob/master/go.sum
+  detection_source: go.mod
+  last_updated_by: andreaspenz
+  last_updated_on: 2022-11-01 17:27:34.000000000 Z
+- name: go-homedir
+  description: Go library for detecting and expanding the user's home directory without
+    cgo
+  package_url: https://pkg.go.dev/github.com/mitchellh/go-homedir
+  version: 1.1.0
+  license: MIT
+  open_source: true
+  hosted_saas: false
+  category: Libraries
+  sub_category: Go Modules Packages
+  image_url: https://img.stackshare.io/package/go-packages/image.png
+  detection_source_url: https://github.com/spryker-community/shadow/blob/master/go.sum
+  detection_source: go.mod
+  last_updated_by: andreaspenz
+  last_updated_on: 2022-11-01 17:27:34.000000000 Z
+- name: go-isatty
+  description: Package isatty implements interface to isatty
+  package_url: https://pkg.go.dev/github.com/mattn/go-isatty
+  version: 0.0.14
+  license: MIT
+  open_source: true
+  hosted_saas: false
+  category: Libraries
+  sub_category: Go Modules Packages
+  image_url: https://img.stackshare.io/package/go-packages/image.png
+  detection_source_url: https://github.com/spryker-community/shadow/blob/master/go.sum
+  detection_source: go.mod
+  last_updated_by: andreaspenz
+  last_updated_on: 2022-11-01 17:27:34.000000000 Z
+- name: go-runewidth
+  description: Go-runewidth Provides functions to get fixed width of the character
+    or string
+  package_url: https://pkg.go.dev/github.com/mattn/go-runewidth
+  version: 0.0.9
+  license: MIT
+  open_source: true
+  hosted_saas: false
+  category: Libraries
+  sub_category: Go Modules Packages
+  image_url: https://img.stackshare.io/package/go-packages/image.png
+  detection_source_url: https://github.com/spryker-community/shadow/blob/master/go.sum
+  detection_source: go.mod
+  last_updated_by: andreaspenz
+  last_updated_on: 2022-11-01 17:27:34.000000000 Z
+- name: kr/text
+  description: Miscellaneous functions for formatting text
+  package_url: https://pkg.go.dev/github.com/kr/text
+  version: 0.1.0
+  license: MIT
+  open_source: true
+  hosted_saas: false
+  category: Libraries
+  sub_category: Go Modules Packages
+  image_url: https://img.stackshare.io/package/go-packages/image.png
+  detection_source_url: https://github.com/spryker-community/shadow/blob/master/go.sum
+  detection_source: go.mod
+  last_updated_by: andreaspenz
+  last_updated_on: 2022-11-01 17:27:34.000000000 Z
+- name: pretty
+  description: Pretty printing for Go values
+  package_url: https://pkg.go.dev/github.com/kr/pretty
+  version: 0.1.0
+  license: MIT
+  open_source: true
+  hosted_saas: false
+  category: Libraries
+  sub_category: Go Modules Packages
+  image_url: https://img.stackshare.io/package/go-packages/image.png
+  detection_source_url: https://github.com/spryker-community/shadow/blob/master/go.sum
+  detection_source: go.mod
+  last_updated_by: andreaspenz
+  last_updated_on: 2022-11-01 17:27:34.000000000 Z
+- name: sys
+  description: Go packages for low-level interaction with the operating system
+  package_url: https://pkg.go.dev/golang.org/x/sys
+  version: 0.0.0
+  license: BSD-3-Clause
+  open_source: true
+  hosted_saas: false
+  category: Libraries
+  sub_category: Go Modules Packages
+  image_url: https://img.stackshare.io/package/go-packages/image.png
+  detection_source_url: https://github.com/spryker-community/shadow/blob/master/go.sum
+  detection_source: go.mod
+  last_updated_by: andreaspenz
+  last_updated_on: 2022-11-01 17:27:34.000000000 Z
+- name: tablewriter
+  description: ASCII table in golang
+  package_url: https://pkg.go.dev/github.com/olekukonko/tablewriter
+  version: 0.0.5
+  license: MIT
+  open_source: true
+  hosted_saas: false
+  category: Libraries
+  sub_category: Go Modules Packages
+  image_url: https://img.stackshare.io/package/go-packages/image.png
+  detection_source_url: https://github.com/spryker-community/shadow/blob/master/go.sum
+  detection_source: go.mod
+  last_updated_by: andreaspenz
+  last_updated_on: 2022-11-01 17:27:34.000000000 Z
+- name: text
+  description: Go text processing support
+  package_url: https://pkg.go.dev/golang.org/x/text
+  version: 0.0.0
+  license: BSD-3-Clause
+  open_source: true
+  hosted_saas: false
+  category: Libraries
+  sub_category: Go Modules Packages
+  image_url: https://img.stackshare.io/package/go-packages/image.png
+  detection_source_url: https://github.com/spryker-community/shadow/blob/master/go.sum
+  detection_source: go.mod
+  last_updated_by: andreaspenz
+  last_updated_on: 2022-11-01 17:27:34.000000000 Z
+- name: zerolog
+  description: Zero Allocation JSON Logger
+  package_url: https://pkg.go.dev/github.com/rs/zerolog
+  version: 1.26.0
+  license: MIT
+  open_source: true
+  hosted_saas: false
+  category: Libraries
+  sub_category: Go Modules Packages
+  image_url: https://img.stackshare.io/package/go-packages/image.png
+  detection_source_url: https://github.com/spryker-community/shadow/blob/master/go.sum
+  detection_source: go.mod
+  last_updated_by: andreaspenz
+  last_updated_on: 2022-11-01 17:27:34.000000000 Z


### PR DESCRIPTION
PR to add tech stack documentation to allow anyone to easily see what is being used in this repo without digging through config files. Two files are being added: techstack.yml and techstack.md. The techstack.yml file contains data on all the tools being used in this repo. The techstack.md file is derived from the YML file and displays the tech stack data in Markdown.